### PR TITLE
[refact] Run 'conanfile::build()' only once in the sources (#6602)

### DIFF
--- a/conans/client/build/build.py
+++ b/conans/client/build/build.py
@@ -1,0 +1,18 @@
+
+import os
+
+from conans.errors import conanfile_exception_formatter
+from conans.model.conan_file import get_env_context_manager
+from conans.util.log import logger
+
+
+def run_build_method(conanfile, hook_manager, **hook_kwargs):
+    hook_manager.execute("pre_build", conanfile=conanfile, **hook_kwargs)
+
+    logger.debug("Call conanfile.build() with files in build folder: %s", os.listdir(conanfile.build_folder))
+    with get_env_context_manager(conanfile):
+        conanfile.output.highlight("Calling build()")
+        with conanfile_exception_formatter(str(conanfile), "build"):
+            conanfile.build()
+
+    hook_manager.execute("post_build", conanfile=conanfile, **hook_kwargs)

--- a/conans/client/cmd/build.py
+++ b/conans/client/cmd/build.py
@@ -1,5 +1,6 @@
 import os
 
+from conans.client.build.build import run_build_method
 from conans.errors import (ConanException, NotFoundException, conanfile_exception_formatter)
 from conans.model.conan_file import get_env_context_manager
 from conans.paths import CONANFILE, CONANFILE_TXT
@@ -44,15 +45,9 @@ def cmd_build(app, conanfile_path, source_folder, build_folder, package_folder, 
         conan_file.source_folder = source_folder
         conan_file.package_folder = package_folder
         conan_file.install_folder = install_folder
-        app.hook_manager.execute("pre_build", conanfile=conan_file,
-                                 conanfile_path=conanfile_path)
-        with get_env_context_manager(conan_file):
-            conan_file.output.highlight("Running build()")
-            with conanfile_exception_formatter(str(conan_file), "build"):
-                conan_file.build()
-            app.hook_manager.execute("post_build", conanfile=conan_file,
-                                     conanfile_path=conanfile_path)
-            if test:
+        run_build_method(conan_file, app.hook_manager, conanfile_path=conanfile_path)
+        if test:
+            with get_env_context_manager(conan_file):
                 conan_file.output.highlight("Running test()")
                 with conanfile_exception_formatter(str(conan_file), "test"):
                     conan_file.test()

--- a/conans/test/functional/options/options_test.py
+++ b/conans/test/functional/options/options_test.py
@@ -49,7 +49,7 @@ class Pkg(ConanFile):
                      "test_package/conanfile.py": test})
         client.run("create . Pkg/0.1@user/testing -o *:shared=True")
         self.assertIn("Pkg/0.1@user/testing: Calling build()", client.out)
-        self.assertIn("Pkg/0.1@user/testing (test package): Running build()", client.out)
+        self.assertIn("Pkg/0.1@user/testing (test package): Calling build()", client.out)
 
     def general_scope_priorities_test(self):
         client = TestClient()

--- a/conans/test/unittests/tools/files_patch_test.py
+++ b/conans/test/unittests/tools/files_patch_test.py
@@ -253,7 +253,7 @@ class ToolsFilesPatchTest(unittest.TestCase):
         foo_content = client.load("foo.txt")
         self.assertIn(dedent("""For us, there is no spring.
 Just the wind that smells fresh before the storm."""), foo_content)
-        self.assertIn("Running build()", client.out)
+        self.assertIn("Calling build()", client.out)
         self.assertNotIn("Warning", client.out)
 
     def _save_files(self, file_content):


### PR DESCRIPTION
* run build and related hooks in one single point

* duplicate arg

* prefer calling

* need to change the tests, message changes

* rename to 'run_build_method'

* build_folder is already assigned to the conanfile

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
