### PR TITLE
CMake overwrites Conan VS runtime when CMP0091 is NEW (#6626)

### DIFF
--- a/conans/client/generators/cmake_common.py
+++ b/conans/client/generators/cmake_common.py
@@ -223,6 +223,18 @@ class CMakeCommonMacros:
         endfunction()
     """)
 
+    # this function gets the policy without raising an error for earlier versions than the policy
+    conan_get_policy = textwrap.dedent("""
+        function(conan_get_policy policy_id policy)
+            if(POLICY "${policy_id}")
+                cmake_policy(GET "${policy_id}" _policy)
+                set(policy "${_policy}" PARENT_SCOPE)
+            else()
+                set(policy "" PARENT_SCOPE) 
+            endif()
+        endfunction()
+    """)
+
     conan_find_libraries_abs_path = textwrap.dedent("""
         function(conan_find_libraries_abs_path libraries package_libdir libraries_abs_path)
             foreach(_LIBRARY_NAME ${libraries})
@@ -652,18 +664,31 @@ class CMakeCommonMacros:
     conan_set_vs_runtime = textwrap.dedent("""
         macro(conan_set_vs_runtime)
             if(CONAN_LINK_RUNTIME)
-                foreach(flag CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE
-                             CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO
-                             CMAKE_C_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_MINSIZEREL)
-                    if(DEFINED ${flag})
-                        string(REPLACE "/MD" ${CONAN_LINK_RUNTIME} ${flag} "${${flag}}")
+                conan_get_policy(CMP0091 policy_0091)
+                if(policy_0091 STREQUAL "NEW")
+                    if(CONAN_LINK_RUNTIME MATCHES "MTd")
+                        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDebug")
+                    elseif(CONAN_LINK_RUNTIME MATCHES "MDd")
+                        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDebugDLL")
+                    elseif(CONAN_LINK_RUNTIME MATCHES "MT")
+                        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
+                    elseif(CONAN_LINK_RUNTIME MATCHES "MD")
+                        set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
                     endif()
-                endforeach()
-                foreach(flag CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG)
-                    if(DEFINED ${flag})
-                        string(REPLACE "/MDd" ${CONAN_LINK_RUNTIME} ${flag} "${${flag}}")
-                    endif()
-                endforeach()
+                else()
+                    foreach(flag CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE
+                                 CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO
+                                 CMAKE_C_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_MINSIZEREL)
+                        if(DEFINED ${flag})
+                            string(REPLACE "/MD" ${CONAN_LINK_RUNTIME} ${flag} "${${flag}}")
+                        endif()
+                    endforeach()
+                    foreach(flag CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG)
+                        if(DEFINED ${flag})
+                            string(REPLACE "/MDd" ${CONAN_LINK_RUNTIME} ${flag} "${${flag}}")
+                        endif()
+                    endforeach()
+                endif()
             endif()
         endmacro()
     """)
@@ -674,19 +699,34 @@ class CMakeCommonMacros:
             # Leave the defaults MD (MDd) or replace them with MT (MTd) but taking into account the
             # debug, forcing MXd for debug builds. It will generate MSVCRT warnings if the dependencies
             # are installed with "conan install" and the wrong build type.
+            conan_get_policy(CMP0091 policy_0091)
             if(CONAN_LINK_RUNTIME MATCHES "MT")
-                foreach(flag CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE
-                                 CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO
-                                 CMAKE_C_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_MINSIZEREL)
-                    if(DEFINED ${flag})
-                        string(REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+                if(policy_0091 STREQUAL "NEW")
+                    if(CMAKE_BUILD_TYPE STREQUAL "Release" OR
+                       CMAKE_BUILD_TYPE STREQUAL "RelWithDebInfo" OR
+                       CMAKE_BUILD_TYPE STREQUAL "MinSizeRel")
+                        if (CMAKE_MSVC_RUNTIME_LIBRARY STREQUAL "MultiThreadedDLL")
+                            set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
+                        endif()
+                    elseif(CMAKE_BUILD_TYPE STREQUAL "Debug")
+                        if (CMAKE_MSVC_RUNTIME_LIBRARY STREQUAL "MultiThreadedDebugDLL")
+                            set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDebug")
+                        endif()
                     endif()
-                endforeach()
-                foreach(flag CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG)
-                    if(DEFINED ${flag})
-                        string(REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
-                    endif()
-                endforeach()
+                else()
+                    foreach(flag CMAKE_C_FLAGS_RELEASE CMAKE_CXX_FLAGS_RELEASE
+                                    CMAKE_C_FLAGS_RELWITHDEBINFO CMAKE_CXX_FLAGS_RELWITHDEBINFO
+                                    CMAKE_C_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_MINSIZEREL)
+                        if(DEFINED ${flag})
+                            string(REPLACE "/MD" "/MT" ${flag} "${${flag}}")
+                        endif()
+                    endforeach()
+                    foreach(flag CMAKE_C_FLAGS_DEBUG CMAKE_CXX_FLAGS_DEBUG)
+                        if(DEFINED ${flag})
+                            string(REPLACE "/MDd" "/MTd" ${flag} "${${flag}}")
+                        endif()
+                    endforeach()
+                endif()
             endif()
         endmacro()
     """)
@@ -780,6 +820,7 @@ class CMakeCommonMacros:
 
 _cmake_common_macros = "\n".join([
     CMakeCommonMacros.conan_message,
+    CMakeCommonMacros.conan_get_policy,
     CMakeCommonMacros.conan_find_libraries_abs_path,
     CMakeCommonMacros.conan_package_library_targets,
     CMakeCommonMacros.conan_set_libcxx,


### PR DESCRIPTION
* check 0091 policy in conan_set_runtime

* use matches

* minor changes

* add conan function to get policies

* minor changes

Changelog: (Feature | Fix | Bugfix): Describe here your pull request
Docs: https://github.com/conan-io/docs/pull/XXXX

- [ ] Refer to the issue that supports this Pull Request.
- [ ] If the issue has missing info, explain the purpose/use case/pain/need that covers this Pull Request.
- [ ] I've read the [Contributing guide](https://github.com/conan-io/conan/blob/develop/.github/CONTRIBUTING.md).
- [ ] I've followed the PEP8 style guides for Python code.
- [ ] I've opened another PR in the Conan docs repo to the ``develop`` branch, documenting this one. 

<sup>**Note:** By default this PR will skip the slower tests and will use a limited set of python versions. Check [here](https://github.com/conan-io/conan/blob/develop/.github/PR_INCREASE_TESTING.md) how to increase the testing level by writing some tags in the current PR body text.</sup>
